### PR TITLE
scanHost function name 

### DIFF
--- a/src/terminal_nmap.py
+++ b/src/terminal_nmap.py
@@ -24,7 +24,7 @@ def scanNetwork(network):
             print(f'{scanner[host]["hostnames"][0]["name"]}')
         
 
-def scanHost(network, ports):
+def scan_host(network, ports):
     print(f"Scanning network {network}...")
     scanner.scan(hosts=network, arguments=f"-p {ports}")
     for host in scanner.all_hosts():

--- a/src/terminal_nmap.py
+++ b/src/terminal_nmap.py
@@ -72,7 +72,7 @@ def option2_screen():
             break
         else:
             ports = Prompt.ask("Agora digite o intervalo de portas dado esse formato:\n    [italic white]<menor porta>-<maior porta>[/italic white]", default="1-1000")
-            scanHost(choice, ports)
+            scan_host(choice, ports)
             Prompt.ask("[bold red]aperte 'ENTER' para continuar[/bold red]")
             break
             


### PR DESCRIPTION
Closes #3 

Switched the function name from `scanHost` to `scan_host`, and corrected the function calls in order to change to the new function name.