### PR TITLE
Criação de testes para a funcao scan_hosts

### DIFF
--- a/src/terminal_nmap.py
+++ b/src/terminal_nmap.py
@@ -25,19 +25,19 @@ def scan_network(network):
             print(f'{scanner[host]["hostnames"][0]["name"]}')
 
 
-def scan_host(network, ports):
+def scan_host(network, ports, function_scanner):
     """Print scan results for a single host"""
     print(f"Scanning network {network}...")
-    scanner.scan(hosts=network, arguments=f"-p {ports}")
-    for host in scanner.all_hosts():
+    function_scanner.scan(hosts=network, arguments=f"-p {ports}")
+    for host in function_scanner.all_hosts():
         print(f"\nScan results for {host}:")
-        for proto in scanner[host].all_protocols():
+        for proto in function_scanner[host].all_protocols():
             print(f"Protocol : {proto}")
-            lport = scanner[host][proto].keys()
+            lport = function_scanner[host][proto].keys()
             lport = sorted(lport)
             for port in lport:
-                print(f"port: {port} ({scanner[host][proto][port]['name']})")
-                print(f"state: {scanner[host][proto][port]['state']}")
+                print(f"port: {port} ({function_scanner[host][proto][port]['name']})")
+                print(f"state: {function_scanner[host][proto][port]['state']}")
 
 
 console = Console()
@@ -94,7 +94,7 @@ def option2_screen():
             default="1-1000",
         )
 
-        scan_host(choice, ports)
+        scan_host(choice, ports, scanner)
         Prompt.ask("[bold red]aperte 'ENTER' para continuar[/bold red]")
 
 

--- a/src/test.py
+++ b/src/test.py
@@ -1,0 +1,35 @@
+from unittest.mock import Mock, MagicMock, patch, call
+from terminal_nmap import scan_host
+import unittest
+
+class TestScanHost(unittest.TestCase):
+
+    @patch('builtins.print') # Para substituir o print padrao do python
+    def test_scan_host_range(self, mock_print):
+        mock_scanner = MagicMock()
+
+        mock_scanner.all_hosts.return_value = ['127.0.0.1']
+        mock_scanner.__getitem__.return_value.all_protocols.return_value = ['tcp']
+        mock_scanner.__getitem__.return_value.__getitem__.return_value.keys.return_value = ['80']
+        mock_scanner.__getitem__.return_value.__getitem__.return_value.__getitem__.return_value = {'name': 'http', 'state': 'open'}
+
+        scan_host('www.uol.com.br', '80-1000', mock_scanner)
+
+        mock_scanner.scan.assert_called_once_with(hosts='www.uol.com.br', arguments='-p 80-1000')
+
+        # Verificar o output da função
+        calls = [call('Scanning network www.uol.com.br...'),
+                 call('\nScan results for 127.0.0.1:'),
+                 call('Protocol : tcp'),
+                 call('port: 80 (http)'),
+                 call('state: open')]
+        mock_print.assert_has_calls(calls, any_order=True)
+        
+        """
+        Cabe dizer que ao realizar o mock do Scanner, o segundo argumento passado na funcao scan_host, que é o 'ports', não é utilizado.
+        Visto que no código, esse parâmetro é repassada para a chamada da função scan do nmap.
+        Ao utilizar o mock, ainda que esses valores sejam passados, o retorno da função scan_host será sempre o mesmo.
+        """
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
close #34 

### Registro de Alterações
---

**Criação do arquivo: test.py**

Um novo arquivo test.py foi criado para incluir testes unitários para a função scan_host. O módulo unittest foi utilizado para estruturar os testes, e o módulo unittest.mock foi usado para criar objetos simulados (mocks).

Segue um exemplo do modelo utilizado 

```
from unittest.mock import Mock, MagicMock, patch, call
from terminal_nmap import scan_host
import unittest

class TestScanHost(unittest.TestCase):
    # Métodos de teste...
```

---

**Refatoração: função scan_host**

A função scan_host em terminal_nmap.py foi refatorada para receber o scanner como um argumento, em vez de usar uma variável global do scanner. Essa mudança permite que a função seja testada isoladamente, sem quaisquer dependências do estado global.

Essa refatoração torna a função scan_host mais modular e testável. Agora ela pode ser testada independentemente do restante do sistema, e os testes podem controlar suas dependências usando objetos simulados.

